### PR TITLE
Generalize key mappings via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ mappings use action names (e.g. `RIGHT`, `FIRE`) which are converted to
 the correct action indices at runtime, so unsupported actions simply
 fall back to `NOOP`.
 
+Holding a direction together with the spacebar will trigger the
+corresponding `*FIRE` combination (e.g. Right + Space = `RIGHTFIRE`) when
+the game supports it.
+
 You can hold multiple direction keys together to combine actions (for example,
 Up + Right to move forward while turning). Running, strafing and firing can also
 be combined with movement.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ For VizDoom environments the keys are mapped automatically so that:
 
 Key mappings for Atari, VizDoom and stable-retro environments are now
 configured through a shared data structure in `main.py`. Edit the mapping
-there if you want to customize controls for a specific game.
+there if you want to customize controls for a specific game.  Atari
+mappings use action names (e.g. `RIGHT`, `FIRE`) which are converted to
+the correct action indices at runtime, so unsupported actions simply
+fall back to `NOOP`.
 
 You can hold multiple direction keys together to combine actions (for example,
 Up + Right to move forward while turning). Running, strafing and firing can also

--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ cp .env.example .env
 python main.py record BreakoutNoFrameskip-v4
 ```
 
-This will open a pygame window where you can play Breakout. Use the following controls:
-- Space: Action 1
-- Right Arrow: Action 2
-- Left Arrow: Action 3
 
 For VizDoom environments the keys are mapped automatically so that:
 - Arrow keys move forward/backward and turn left/right
@@ -65,6 +61,30 @@ Up + Right to move forward while turning). Running, strafing and firing can also
 be combined with movement.
 
 The session will be automatically saved as a dataset and uploaded to Hugging Face Hub if you've provided a token.
+### Default key mappings
+
+The tables below show the default keyboard controls for each environment type.
+
+#### Atari (gymnasium ALE)
+- Arrow keys move the agent
+- Spacebar fires/jumps
+- Direction + Space triggers the matching `*FIRE` action
+- Diagonal directions are supported when available
+
+#### stable-retro consoles (NES, SNES, GB, Genesis)
+- Z: A button
+- X: B button
+- Q: SELECT
+- R: START
+- Arrow keys: D-pad directions
+
+#### VizDoom
+- Up/Down arrows: MOVE_FORWARD / MOVE_BACKWARD
+- Left/Right arrows: TURN_LEFT / TURN_RIGHT (hold Alt to strafe)
+- Shift: SPEED (run)
+- Ctrl: ATTACK
+- Spacebar: USE
+- Number keys 1-7: SELECT_WEAPON1-7
 
 ### Replaying a recorded session
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ For VizDoom environments the keys are mapped automatically so that:
 - Spacebar performs the `USE` action (open doors, switches)
 - Number keys 1–7 select weapons if available
 
+Key mappings for Atari, VizDoom and stable-retro environments are now
+configured through a shared data structure in `main.py`. Edit the mapping
+there if you want to customize controls for a specific game.
+
 You can hold multiple direction keys together to combine actions (for example,
 Up + Right to move forward while turning). Running, strafing and firing can also
 be combined with movement.

--- a/main.py
+++ b/main.py
@@ -6,8 +6,7 @@ import pygame
 import threading
 import asyncio
 import tempfile
-from dataclasses import dataclass
-from typing import Callable, Dict, Iterable, Optional
+from typing import Dict, Iterable, Optional
 from PIL import Image as PILImage
 from datasets import Dataset, Features, Value, Sequence, Image as HFImage, load_dataset, concatenate_datasets
 from huggingface_hub import whoami

--- a/main.py
+++ b/main.py
@@ -30,7 +30,8 @@ ATARI_KEY_CONFIG = {
     "noop": 0,
     "mapping": {
         # Map keys to action names; indices are resolved at runtime
-        pygame.K_UP: "FIRE",     # Start / fire
+        pygame.K_SPACE: "FIRE",
+        pygame.K_UP: "UP",
         pygame.K_RIGHT: "RIGHT",
         pygame.K_LEFT: "LEFT",
         pygame.K_DOWN: "DOWN",   # Fallback to NOOP if unsupported


### PR DESCRIPTION
## Summary
- dry up key mapping logic by creating `KeyMapper`
- use configuration dictionaries for Atari, stable-retro and VizDoom
- update README with info on customizing key mappings

## Testing
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402bba338083328debaab91027bfa7