### PR TITLE
Add ESC key exit with dataset upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can hold multiple direction keys together to combine actions (for example,
 Up + Right to move forward while turning). Running, strafing and firing can also
 be combined with movement.
 
-The session will be automatically saved as a dataset and uploaded to Hugging Face Hub if you've provided a token.
+Press `ESC` at any time to stop playing and automatically upload the frames recorded so far. If you want to exit without uploading you can press `Ctrl+C` instead. The session will be automatically saved as a dataset and uploaded to Hugging Face Hub if you've provided a token.
 
 ### Replaying a recorded session
 

--- a/main.py
+++ b/main.py
@@ -98,9 +98,13 @@ class DatasetRecorderWrapper(gym.Wrapper):
         Handle pygame input events.
         """
         for event in pygame.event.get():
-            if event.type == pygame.QUIT: return False
+            if event.type == pygame.QUIT:
+                return False
             elif event.type == pygame.KEYDOWN:
-                with self.key_lock: self.current_keys.add(event.key)
+                if event.key == pygame.K_ESCAPE:
+                    return False
+                with self.key_lock:
+                    self.current_keys.add(event.key)
             elif event.type == pygame.KEYUP:
                 with self.key_lock: self.current_keys.discard(event.key)
         return True


### PR DESCRIPTION
## Summary
- let ESC close the game window and upload the recorded frames
- document ESC/Ctrl+C behaviour in the readme

## Testing
- `python -m py_compile main.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68403bf1ff348332a376426bddcff3bf