### PR TITLE
Add environment listing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ python main.py list_environments
 ```
 
 This will print all Atari environments, all stable-retro games with ROM availability
-indicated, and any VizDoom environments found (including WADs if present).
+indicated using `(imported)` or `(missing ROM)`, and any VizDoom environments
+found (including WADs if present).
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ This will replay a previously recorded session from Hugging Face Hub, allowing y
 python main.py list_environments
 ```
 
-This will print all Atari, stable-retro and VizDoom environments detected on your system.
+This will print all Atari environments, all stable-retro games with ROM availability
+indicated, and any VizDoom environments found (including WADs if present).
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ python main.py playback BreakoutNoFrameskip-v4
 
 This will replay a previously recorded session from Hugging Face Hub, allowing you to verify the environment's deterministic behavior.
 
+### Listing available environments
+
+```bash
+python main.py list_environments
+```
+
+This will print all Atari, stable-retro and VizDoom environments detected on your system.
+
 ## 📄 License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/main.py
+++ b/main.py
@@ -582,8 +582,11 @@ def list_environments():
         if all_games:
             print("\n=== Stable-Retro Games ===")
             for game in all_games:
-                available = retro.data.get_file_path(game, "rom.sha") is not None
-                status = "(imported)" if available else "(missing ROM)"
+                try:
+                    retro.data.get_romfile_path(game, retro.data.Integrations.ALL)
+                    status = "(imported)"
+                except FileNotFoundError:
+                    status = "(missing ROM)"
                 print(f"{game} {status}")
         else:
             print("\nStable-Retro package installed but no games found.")

--- a/main.py
+++ b/main.py
@@ -567,7 +567,9 @@ def list_environments():
         import ale_py
         gym.register_envs(ale_py)
         atari_ids = sorted(
-            env_id for env_id in gym.envs.registry.keys() if env_id.startswith("ALE/")
+            env_id
+            for env_id in gym.envs.registry.keys()
+            if str(gym.spec(env_id).entry_point) == "ale_py.env:AtariEnv"
         )
         for env_id in atari_ids:
             print(env_id)
@@ -576,15 +578,17 @@ def list_environments():
 
     try:
         import retro
-        games = sorted(retro.data.list_games())
-        if games:
+        all_games = sorted(retro.data.list_games(retro.data.Integrations.ALL))
+        if all_games:
             print("\n=== Stable-Retro Games ===")
-            for game in games:
-                print(game)
+            for game in all_games:
+                available = retro.data.get_file_path(game, "rom.sha") is not None
+                status = "(imported)" if available else "(missing ROM)"
+                print(f"{game} {status}")
         else:
-            print("\nStable-Retro installed but no ROMs imported.")
-    except Exception:
-        print("\nStable-Retro not installed.")
+            print("\nStable-Retro package installed but no games found.")
+    except Exception as e:
+        print(f"\nStable-Retro not installed: {e}")
 
     try:
         import vizdoom


### PR DESCRIPTION
## Summary
- implement `list_environments` command to display Atari, stable-retro and VizDoom envs
- rework CLI to use subcommands
- document usage for listing environments

## Testing
- `pytest -q`
- `python main.py list_environments | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68406caf10fc8332bbb3408be54bc069