### PR TITLE
Use JPEG encoding with OpenCV

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 gymnasium-recorder is a tool that wraps [Gymnasium ALE environments](https://ale.farama.org/environments/) (specifically Atari games) to record gameplay sessions as datasets. It captures frames and actions during interactive play, saving them as structured datasets that can be uploaded to Hugging Face Hub.
 
+Frames are stored as JPEG images using OpenCV for faster write performance.
+
 The tool provides a pygame interface for playing Atari games while recording your actions, making it easy to create training datasets for reinforcement learning models. It also supports replaying recorded sessions to verify environment determinism.
 
 ## 🚀 Installation

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 - Add dataset streaming support
 - Add Doom WAD support
 - Add dataset streaming support
-- Use JPEG + cv2.imwrite for speed
+- ~~Use JPEG + cv2.imwrite for speed~~ (done)
 - Add "timestamp" and "env_id" to dataset schema
 - Add validation for dataset fields
 - Add a flag to skip uploads and save locally

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
       - gymnasium[atari]
       - gymnasium[vizdoom]
       - datasets
+      - opencv-python

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import pygame
 import threading
 import asyncio
 import tempfile
-from PIL import Image as PILImage
+import cv2
 from datasets import Dataset, Features, Value, Sequence, Image as HFImage, load_dataset, concatenate_datasets
 from huggingface_hub import whoami, DatasetCard, DatasetCardData
 import argparse
@@ -254,9 +254,10 @@ class DatasetRecorderWrapper(gym.Wrapper):
                     frame = frame[k]
                     break
 
-        img = PILImage.fromarray(frame.astype(np.uint8))
-        path = os.path.join(self.temp_dir, f"frame_{len(self.frames):05d}.png")
-        img.save(path, format="PNG")
+        frame_uint8 = frame.astype(np.uint8)
+        frame_bgr = cv2.cvtColor(frame_uint8, cv2.COLOR_RGB2BGR)
+        path = os.path.join(self.temp_dir, f"frame_{len(self.frames):05d}.jpg")
+        cv2.imwrite(path, frame_bgr, [int(cv2.IMWRITE_JPEG_QUALITY), 95])
         self.episode_ids.append(episode_id)
         self.steps.append(step)
         self.frames.append(path)


### PR DESCRIPTION
## Summary
- compress recorded frames with JPEG via OpenCV
- document JPEG frame storage in README
- update environment to include opencv-python
- mark the JPEG TODO item as done

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68408694f9c48332aa06b53958773c3a