### PR TITLE
Add timestamp/env_id columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 gymnasium-recorder is a tool that wraps [Gymnasium ALE environments](https://ale.farama.org/environments/) (specifically Atari games) to record gameplay sessions as datasets. It captures frames and actions during interactive play, saving them as structured datasets that can be uploaded to Hugging Face Hub.
 
+The resulting dataset includes the columns `episode_id`, `env_id`, `timestamp`, `step`, `action`, and `image`.
+
 The tool provides a pygame interface for playing Atari games while recording your actions, making it easy to create training datasets for reinforcement learning models. It also supports replaying recorded sessions to verify environment determinism.
 
 ## 🚀 Installation

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 - Add Doom WAD support
 - Add dataset streaming support
 - Use JPEG + cv2.imwrite for speed
-- Add "timestamp" and "env_id" to dataset schema
 - Add validation for dataset fields
 - Add a flag to skip uploads and save locally
 - Add support to only start game after user input (ignore that action)

--- a/main.py
+++ b/main.py
@@ -222,6 +222,8 @@ class DatasetRecorderWrapper(gym.Wrapper):
         self.frames = []
         self.actions = []
         self.steps = []
+        self.env_ids = []
+        self.timestamps = []
 
         self.temp_dir = tempfile.mkdtemp()
 
@@ -260,6 +262,8 @@ class DatasetRecorderWrapper(gym.Wrapper):
         self.episode_ids.append(episode_id)
         self.steps.append(step)
         self.frames.append(path)
+        self.env_ids.append(self.env.spec.id if self.env and self.env.spec else "unknown")
+        self.timestamps.append(time.time())
         # Normalize action format for dataset storage
         if isinstance(action, np.ndarray):
             action = action.tolist()
@@ -444,6 +448,8 @@ class DatasetRecorderWrapper(gym.Wrapper):
             await self.play(fps=fps)
             data = {
                 "episode_id": self.episode_ids,
+                "env_id": self.env_ids,
+                "timestamp": self.timestamps,
                 "image": self.frames,
                 "step": self.steps,
                 "action": self.actions,
@@ -472,6 +478,8 @@ class DatasetRecorderWrapper(gym.Wrapper):
         self.frames.clear()
         self.actions.clear()
         self.steps.clear()
+        self.env_ids.clear()
+        self.timestamps.clear()
 
         episode_id = int(time.time())
         obs, _ = self.env.reset()


### PR DESCRIPTION
## Summary
- store `env_id` and `timestamp` for every frame
- mention extra columns in README
- update TODO

## Testing
- `python -m py_compile main.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_6840866efb7c8332aa988f4389b9c003