### PR TITLE
Add startup overlay before recording begins

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ You can hold multiple direction keys together to combine actions (for example,
 Up + Right to move forward while turning). Running, strafing and firing can also
 be combined with movement.
 
+When a recording starts, the first game frame is shown with a translucent
+overlay asking you to press <kbd>SPACE</kbd>. This lets you focus the window
+before gameplay begins.
+
 Press `ESC` at any time to stop playing and automatically upload the frames recorded so far. If you want to exit without uploading you can press `Ctrl+C` instead. The session will be automatically saved as a dataset and uploaded to Hugging Face Hub if you've provided a token.
 
 ### Replaying a recorded session

--- a/TODO.md
+++ b/TODO.md
@@ -5,4 +5,4 @@
 - Add "timestamp" and "env_id" to dataset schema
 - Add validation for dataset fields
 - Add a flag to skip uploads and save locally
-- Add support to only start game after user input (ignore that action)
+- ~~Add support to only start game after user input (ignore that action)~~ (done)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import pygame
 import threading
 import asyncio
 import tempfile
+from typing import Optional
 from PIL import Image as PILImage
 from datasets import Dataset, Features, Value, Sequence, Image as HFImage, load_dataset, concatenate_datasets
 from huggingface_hub import whoami, DatasetCard, DatasetCardData
@@ -18,6 +19,7 @@ load_dotenv(override=True)  # Load environment variables from .env file
 import gymnasium as gym
 
 REPO_PREFIX = "GymnasiumRecording__"
+START_KEY = pygame.K_SPACE
 
 # Default key mappings for each supported environment type
 ATARI_KEY_BINDINGS = {
@@ -430,6 +432,37 @@ class DatasetRecorderWrapper(gym.Wrapper):
         self.screen.blit(scaled_surface, (0, 0))
         pygame.display.flip()
 
+    def _wait_for_start(self, start_key: int = START_KEY) -> bool:
+        """Display overlay prompting the user to start.
+
+        Returns True if the start key was pressed, False if the user closed the
+        window or pressed ESC.
+        """
+        if self.screen is None:
+            return True
+
+        font = pygame.font.Font(None, 48)
+        text = font.render("Press SPACE to start", True, (255, 255, 255))
+        overlay = pygame.Surface(self.screen.get_size(), pygame.SRCALPHA)
+        overlay.fill((0, 0, 0, 180))
+        text_rect = text.get_rect(center=(self.screen.get_width() // 2, self.screen.get_height() // 2))
+
+        clock = pygame.time.Clock()
+        while True:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    return False
+                if event.type == pygame.KEYDOWN:
+                    if event.key == pygame.K_ESCAPE:
+                        return False
+                    if event.key == start_key:
+                        return True
+            # Redraw overlay each frame
+            self.screen.blit(overlay, (0, 0))
+            self.screen.blit(text, text_rect)
+            pygame.display.flip()
+            clock.tick(30)
+
     async def record(self, fps=None):
         """Record a gameplay session at the desired FPS."""
         if fps is None:
@@ -477,6 +510,10 @@ class DatasetRecorderWrapper(gym.Wrapper):
         obs, _ = self.env.reset()
         self._ensure_screen(obs)  # Ensure pygame window is created after first obs
         self._render_frame(obs)
+        if not self._wait_for_start():
+            return
+        with self.key_lock:
+            self.current_keys.clear()
         done = False
         step = 0
         while not done:


### PR DESCRIPTION
## Summary
- add translucent start screen overlay for user focus before recording
- document the new start overlay in README
- check off completed TODO item

## Testing
- `python -m py_compile main.py`
- `python main.py -h` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684086e5a0448332ba5bc0575a4b168f