### PR TITLE
Enable dataset streaming for playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Press `ESC` at any time to stop playing and automatically upload the frames reco
 ### Replaying a recorded session
 
 ```bash
-python main.py playback BreakoutNoFrameskip-v4 --stream
+python main.py playback BreakoutNoFrameskip-v4 --repo-id myuser/GymnasiumRecording__BreakoutNoFrameskip_v4 --stream
 ```
 
-This will replay a previously recorded session from Hugging Face Hub while streaming the dataset, so playback can start immediately without waiting for the full download. Omit `--stream` to download the dataset ahead of time.
+This will replay a previously recorded session from Hugging Face Hub while streaming the dataset, so playback can start immediately without waiting for the full download. The `--repo-id` argument allows playing back datasets from another user. Omit `--stream` to download the dataset ahead of time.
 
 ### Listing available environments
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Press `ESC` at any time to stop playing and automatically upload the frames reco
 ### Replaying a recorded session
 
 ```bash
-python main.py playback BreakoutNoFrameskip-v4
+python main.py playback BreakoutNoFrameskip-v4 --stream
 ```
 
-This will replay a previously recorded session from Hugging Face Hub, allowing you to verify the environment's deterministic behavior.
+This will replay a previously recorded session from Hugging Face Hub while streaming the dataset, so playback can start immediately without waiting for the full download. Omit `--stream` to download the dataset ahead of time.
 
 ### Listing available environments
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-- Add dataset streaming support
+- ~~Add dataset streaming support~~ (implemented)
 - Add Doom WAD support
 - Add validation for dataset fields
 - Make upload optional, in the end ask the user if he wants to upload and make default yes


### PR DESCRIPTION
## Summary
- add `--stream` CLI flag to load datasets via streaming
- if streaming is requested use `load_dataset(..., streaming=True)` and iterate actions
- document streaming playback option in README
- mark TODO item as completed

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68409bd2bb308332b358db6a08db1680