### PR TITLE
Make upload optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ When a recording starts, the first game frame is shown with a translucent
 overlay asking you to press <kbd>SPACE</kbd>. This lets you focus the window
 before gameplay begins.
 
-Press `ESC` at any time to stop playing and automatically upload the frames recorded so far. If you want to exit without uploading you can press `Ctrl+C` instead. The session will be automatically saved as a dataset and uploaded to Hugging Face Hub if you've provided a token.
+Press `ESC` at any time to stop playing. After the recording finishes you will be asked if you want to upload the dataset to Hugging Face Hub (default **Y**). Press `Ctrl+C` to exit immediately without saving or uploading.
 
 ### Replaying a recorded session
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 - Add dataset streaming support
 - Add Doom WAD support
 - Add validation for dataset fields
-- Make upload optional, in the end ask the user if he wants to upload and make default yes
 - BUG: "env_id" is being uploaded as "unknown", consider not uploading and just setting it in dataset card

--- a/main.py
+++ b/main.py
@@ -816,8 +816,12 @@ async def main():
         final_dataset = (
             concatenate_datasets([loaded_dataset, recorded_dataset]) if loaded_dataset else recorded_dataset
         )
-        final_dataset.push_to_hub(hf_repo_id)
-        generate_dataset_card(final_dataset, env_id, hf_repo_id)
+        upload = input("Upload dataset to Hugging Face Hub? [Y/n] ").strip().lower()
+        if upload in ("", "y", "yes"):
+            final_dataset.push_to_hub(hf_repo_id)
+            generate_dataset_card(final_dataset, env_id, hf_repo_id)
+        else:
+            print("Skipping upload. Dataset was not pushed to the hub.")
     elif args.command == "playback":
         assert loaded_dataset is not None, f"Dataset not found: {hf_repo_id}"
         recorder = DatasetRecorderWrapper(env)


### PR DESCRIPTION
## Summary
- ask before pushing dataset to the hub and default to upload
- update docs about the new prompt
- clean up TODO list

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68409c0e6e948332b9b679533356c717